### PR TITLE
Fix version string for Vue dev/peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
     "rollup-plugin-terser": "^5.3.0",
     "rollup-plugin-vue": "^6.0.0-beta.11",
     "typescript": "^3.8.3",
-    "vue": "3.0.2"
+    "vue": "^3.0.0 <3.0.3"
   },
   "peerDependencies": {
-    "vue": "3.0.2"
+    "vue": "^3.0.0 <3.0.3"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
I pinned this to a specific Vue version while trying to work around the bug in 3.0.3, but it shouldn't have been committed that way. This changes it to cover all current Vue 3.x releases except the one that breaks all the icon components.

Once Vue 3.0.4 is released (and presumably fixes the bug) we can update this to `^3.0.0 <3.0.3 || ^3.0.4` and hopefully never touch it again.