### PR TITLE
Remove erroneous `sideEffects` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "phosphor-icons/phosphor-vue",
   "homepage": "https://phosphoricons.com",
-  "sideEffects": false,
   "main": "dist/phosphor-vue.ssr.js",
   "browser": "dist/esm/entry.js",
   "module": "dist/esm/entry.js",


### PR DESCRIPTION
This unfortunately entirely breaks tree-shaking of the library, but pending resolution of vuejs/rollup-plugin-vue#401 that's not something we can really fix on our end. This takes the approach that working-but-too-big is at least better than not working at all.

I'll explore options for directly using the `.vue` files from the src directory, but currently the `@`→`src` alias makes them break in dependent projects.