### PR TITLE
fix: icons not tree-shakable

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -71,8 +71,9 @@ if (!argv.format || argv.format === "es") {
     ...baseConfig,
     external,
     output: {
-      file: "dist/phosphor-vue.esm.js",
-      format: "esm",
+      dir: "dist/esm",
+      format: "es",
+      preserveModules: true,
       exports: "named",
     },
     plugins: [
@@ -105,10 +106,11 @@ if (!argv.format || argv.format === "cjs") {
     external,
     output: {
       compact: true,
-      file: "dist/phosphor-vue.ssr.js",
       format: "cjs",
       name: "PhosphorVue",
       exports: "named",
+      dir: "dist/cjs",
+      preserveModules: true,
       globals,
     },
     plugins: [

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "repository": "phosphor-icons/phosphor-vue",
   "homepage": "https://phosphoricons.com",
   "sideEffects": false,
-  "main": "dist/phosphor-vue.ssr.js",
-  "browser": "dist/phosphor-vue.esm.js",
-  "module": "dist/phosphor-vue.esm.js",
+  "main": "dist/cjs/src/entry.js",
+  "browser": "dist/esm/src/entry.js",
+  "module": "dist/esm/src/entry.js",
   "unpkg": "dist/phosphor-vue.min.js",
   "types": "phosphor-vue.d.ts",
   "files": [


### PR DESCRIPTION
This fixes phosphor-icons/phosphor-vue#10 by changing the rollup config to preserve the modules in separate files.
It enables you to only import the icons you need without importing everything at once.