### PR TITLE
chore(docs): add ruby-phosphor-icons in community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,4 @@ NOTE: Upon cloning this repository, the `/src/components` directory does not exi
 - [phosphor-svelte](https://github.com/haruaki07/phosphor-svelte) ▲ Phosphor icons for Svelte apps
 - [phosphor-r](https://github.com/dreamRs/phosphoricons) ▲ Phosphor icon wrapper for R documents and applications
 - [blade-phosphor-icons](https://github.com/codeat3/blade-phosphor-icons) ▲ Phosphor icons in your Laravel Blade views
+- [ruby-phosphor-icons](https://github.com/maful/ruby-phosphor-icons) ▲ Phosphor icons for Ruby and Rails applications


### PR DESCRIPTION
related to https://github.com/phosphor-icons/homepage/pull/286